### PR TITLE
feat(docs): add dart annotations cheat sheet with various examples

### DIFF
--- a/dart/README.md
+++ b/dart/README.md
@@ -1,5 +1,6 @@
 ## Dart Tips And Tricks
 
+- [Annotations: A Practical Cheat Sheet](./annotations-cheat-sheet/README.md)
 - [BLoC UI Notifications](./bloc-ui-notifications/README.md)
 - [Better Tests](./better-tests/README.md)
 - [Code Cohesion](./code-cohesion/README.md)

--- a/dart/annotations-cheat-sheet/README.md
+++ b/dart/annotations-cheat-sheet/README.md
@@ -1,0 +1,708 @@
+# Dart & Flutter Annotations: A Practical Cheat Sheet
+
+If you've ever scrolled past an annotation like `@immutable` or `@override` and thought "I kind of know what that does… I think," this article is for you. Annotations (aka metadata) are small hints you attach to code that help the analyzer, tooling, and other developers understand intent. They're low-effort, high-impact, and used everywhere in Dart and Flutter — from simple `@mustCallSuper` to performance-focused `@pragma`.
+
+Here you'll get:
+
+- A quick primer on what metadata is in Dart.
+- A practical, narrative guide to commonly used annotations.
+- When to use each annotation (and when not to).
+- Copy‑pasteable examples.
+- Handy tips sprinkled throughout.
+
+> [!NOTE]
+> Code-generation annotations, such as `@JsonSerializable`, `@freezed`, and so on - are very common but fall outside the scope of this discussion.
+
+## What is metadata in Dart?
+
+Metadata is extra information you attach to declarations using annotations. In Dart, annotations are expressions that start with `@` and sit before classes, methods, fields, parameters, and more. The analyzer and tools read them to enable checks, guide optimizations, and improve IDE behavior. You'll see two broad kinds:
+
+- Language and SDK annotations (like `@override`, `@Deprecated`, `@pragma`) that the tools understand out of the box.
+- Package annotations (most commonly `package:meta`) that the analyzer also knows and can enforce.
+
+For a deeper, formal overview, see Metadata | Dart ([dart.dev](https://dart.dev/language/metadata)) .
+
+## How to use
+
+- Core `dart:core` annotations: available by default.
+- `package:meta`: add a [dependency](https://pub.dev/packages/meta) (or use Flutter re‑exports).
+- `package:dart_code_metrics_annotations` (DCM): optional, add [dependency](https://pub.dev/packages/dart_code_metrics_annotations) explicitly.
+
+> [!TIP]
+> Flutter SDK re‑exports a small subset of annotations via import "package:flutter/foundation.dart" so you can use those without adding `meta` to pubspec.yaml.
+
+## Quick Reference
+
+| Score | Annotation                                         | Source    | Description                                         | From SDK       |
+| ----- | -------------------------------------------------- | --------- | --------------------------------------------------- | -------------- |
+| 3️⃣    | [deprecated](#deprecated-core)                     | **core**  | Mark API obsolete; include migration hint           | **Yes** (Dart) |
+| 3️⃣    | [override](#override-core)                         | **core**  | Assert you’re truly overriding a member             | **Yes** (Dart) |
+| 3️⃣    | [awaitNotRequired](#awaitnotrequired-meta)         | meta      | Callers needn’t await this Future                   | No             |
+| 2️⃣    | [doNotStore](#donotstore-meta)                     | meta      | Don’t cache or persist the returned value           | No             |
+| 2️⃣    | [doNotSubmit](#donotsubmit-meta)                   | meta      | Dev‑only; remove before commit                      | No             |
+| 1️⃣    | [experimental](#experimental-meta)                 | meta      | API may change without version bump                 | No             |
+| 2️⃣    | [factory](#factory-meta)                           | meta      | Must return a fresh object (or null)                | **Yes**        |
+| 3️⃣    | [immutable](#immutable-meta)                       | meta      | All instance fields must be final (incl. inherited) | **Yes**        |
+| 1️⃣    | [internal](#internal-meta)                         | meta      | For use inside the declaring package only           | No             |
+| 2️⃣    | [isTest](#istest--istestgroup-meta)                | meta      | Marks a single test entry point                     | No             |
+| 1️⃣    | [isTestGroup](#istest--istestgroup-meta)           | meta      | Marks a test group entry point                      | No             |
+| 2️⃣    | [literal](#literal-meta)                           | meta      | Const constructor should be called with const       | No             |
+| 2️⃣    | [mustBeConst](#mustbeconst-meta-experimental)      | meta      | Parameter must be a compile‑time constant           | No             |
+| 2️⃣    | [mustBeOverridden](#mustbeoverridden-meta)         | meta      | Every concrete subclass must implement this         | No             |
+| 3️⃣    | [mustCallSuper](#mustcallsuper-meta)               | meta      | Overrides must call super implementation            | **Yes**        |
+| 2️⃣    | [nonVirtual](#nonvirtual-meta)                     | meta      | Subclasses cannot override this member              | **Yes**        |
+| 2️⃣    | [optionalTypeArgs](#optionaltypeargs-meta)         | meta      | Allow omitting generic type arguments               | **Yes**        |
+| 2️⃣    | [pragma](#pragma-core)                             | **core**  | Tool/VM/Compiler hint                               | **Yes** (Dart) |
+| 3️⃣    | [protected](#protected-meta)                       | meta      | Use inside library and subclasses (on this)         | **Yes**        |
+| 1️⃣    | [RecordUse](#recorduse-meta-experimental)          | meta      | Record statically resolved calls for tooling        | No             |
+| 1️⃣    | [redeclare](#redeclare-meta-experimental)          | meta      | Extension type redeclares a superinterface member   | No             |
+| 2️⃣    | [reopen](#reopen-meta)                             | meta      | Intentionally reopen a hierarchy for subtyping      | No             |
+| 2️⃣    | [useResult](#useresult-meta)                       | meta      | Warn if return value is ignored                     | No             |
+| 2️⃣    | [visibleForOverriding](#visibleforoverriding-meta) | meta      | Public for override, not for calls                  | **Yes**        |
+| 3️⃣    | [visibleForTesting](#visiblefortesting-meta)       | meta      | Public for tests, not for production                | **Yes**        |
+| 2️⃣    | [Throws](#throws-dcm)                              | **_DCM_** | Declaration may throw; call sites must handle       | No             |
+| 1️⃣    | [AcceptedTypes](#acceptedtypes-dcm)                | **_DCM_** | Restrict Object‑typed values to a type subset       | No             |
+
+## Table of Contents
+
+- **Contracts & Correctness** – `factory`, `mustBeConst`, `mustBeOverridden`, `mustCallSuper`, `nonVirtual`, `override`, `redeclare`.
+- **Visibility & API Design** – `internal`, `protected`, `visibleForOverriding`, `visibleForTesting`.
+- **Const & Construction** – `immutable`, `literal`, `optionalTypeArgs`.
+- **Result & Resource Usage** – `awaitNotRequired`, `doNotStore`, `doNotSubmit`, `useResult`.
+- **Testing Aids** – `isTest`, `isTestGroup`.
+- **Experimental & Versioning** – `deprecated`, `experimental`, `reopen`.
+- **Performance & Tooling Pragmas** – `RecordUse`, `pragma`.
+- **Bonus (DCM)** – `Throws`, `AcceptedTypes`.
+
+---
+
+## Contracts & Correctness
+
+### @override (core)
+
+Why: Prevent silent shadowing. The analyzer confirms the member actually overrides something and matches the signature.
+
+When: Every time you intend to override (methods, getters/setters, operators, fields' implicit accessors).
+
+```dart
+abstract class Animal { void speak() {} }
+
+class Dog extends Animal {
+  @override
+  void speak() => print('Woof!');
+  // void speaks() {} // analyzer: not overriding anything
+}
+```
+
+or [DartPad Example](https://gist.github.com/tsinis/177e62cfdac785c6129f627404bd2cd6)
+
+> [!TIP]
+> Use `@override` even on fields when you intend to override implicit getters/setters. It catches mistakes early.
+
+---
+
+### @mustCallSuper (meta)
+
+Why: Preserve base invariants. Skipping super often leaks resources or skips setup.
+
+When: Lifecycle hooks (Flutter initState/dispose), telemetry, locking state transitions.
+
+```dart
+class BaseState {
+  @mustCallSuper
+  void init() {
+    // register base observers
+  }
+}
+
+class FeatureState extends BaseState {
+  @override
+  void init() {
+    super.init(); // required
+    // feature setup
+  }
+}
+```
+
+or [DartPad Example](https://gist.github.com/tsinis/6c19f6390461c716bc715b49b08e9339)
+
+> [!NOTE]
+> Works on getters/setters too — useful for enforcing checks during property overrides.
+
+---
+
+### @mustBeOverridden (meta)
+
+Why: Turn a concrete member into a required hook for all concrete subclasses.
+
+When: Framework scaffolds where "default behavior" would mislead users.
+
+```dart
+class RouteGuard {
+  @mustBeOverridden
+  bool canEnter() => false; // must be overridden by concrete subclasses
+}
+
+class LoggedInGuard extends RouteGuard {
+  @override
+  bool canEnter() => true;
+}
+// class Missing extends RouteGuard {} // error: must override
+```
+
+or [DartPad Example](https://gist.github.com/tsinis/dbd7cd40cf1b042cdde267130adfe7a5)
+
+> [!TIP]
+> This lets you keep the class concrete (instantiable) while still forcing customization where it matters.
+
+---
+
+### @factory (meta)
+
+Why: Construction semantics are part of your API. This must create a new instance (or return `null`), not a hidden singleton.
+
+When: Builders, clone/factory helpers, Flutter widget factories.
+
+```dart
+class LoggerFactory {
+  @factory // Always returns a new Logger instance
+  static Logger createLogger(String destination) => Logger(destination);
+}
+```
+
+or [DartPad Example](https://gist.github.com/tsinis/05d900047495d8b2adc1824eec66e206)
+
+> [!NOTE]
+> This acts as a guardrail: if shared instances sneak in during refactors, the analyzer will nudge you back.
+
+---
+
+### @nonVirtual (meta)
+
+Why: Freeze critical behavior. Prevent subclasses from changing invariants.
+
+When: Equality/hashCode, protocol version getters, logging gates, security checks.
+
+```dart
+class Entity {
+  @nonVirtual
+  int get schemaVersion => 3;
+
+  @nonVirtual
+  bool get isPersisted => _id != null;
+  int? _id;
+}
+```
+
+or [DartPad Example](https://gist.github.com/tsinis/55a672b2d832aba8a0d56a0e74b4d6cc)
+
+> [!TIP]
+> Combine with `@mustCallSuper` on mutation points to tightly control state transitions.
+
+---
+
+### @mustBeConst (meta, experimental)
+
+Why: Some utilities must accept compile‑time constants, not runtime values.
+
+When: Compile‑time lookups, const‑driven config, string validators that rely on const‑eval.
+
+```dart
+bool isPremium(@mustBeConst String flag) => flag == 'PREMIUM';
+
+const u = 'PREMIUM';
+final r = DateTime.now().toString();
+void checkFlags() {
+  isPremium(u); // OK
+  isPremium(r); // Error: not const
+}
+```
+
+or [DartPad Example](https://gist.github.com/tsinis/75b40e6f85680ae6cf604e65f8eefa4c)
+
+> [!NOTE]
+> Overrides don't inherit this requirement — re‑annotate in subclasses to keep the contract.
+
+---
+
+### @redeclare (meta, experimental)
+
+Why: Make it explicit that an extension type intentionally redeclares a superinterface member.
+
+When: Extension types implementing common protocols with specialized semantics.
+
+```dart
+extension type NonNegInt(int value) implements Comparable<int> {
+  @redeclare
+  int compareTo(int other) => value.compareTo(other);
+}
+```
+
+or [DartPad Example](https://gist.github.com/tsinis/427fbd19ef50b18544a21e18adae903b)
+
+> [!TIP]
+> Helps tools keep your intent tied to interface changes across versions.
+
+---
+
+## Visibility & API Design
+
+### @internal (meta)
+
+Why: "Package‑private" by convention. External use is possible, but tools will warn.
+
+When: Implementation details, helpers, mini‑framework guts.
+
+```dart
+@internal
+class ParseCursor {/* ... */}
+```
+
+or [DartPad Example](https://gist.github.com/tsinis/1ec2311b4fd7b9ee159ceb12d3024467)
+
+> [!TIP]
+> If downstream packages depend on `@internal` APIs, you'll see warnings during review — avoid accidental public contracts.
+
+---
+
+### @protected (meta)
+
+Why: For subclass/library use and on this instance only. Encourages safe extension points.
+
+When: Subclass hooks and internal helpers.
+
+```dart
+class Bloc {
+  @protected
+  void notify() {/*...*/}
+}
+
+class UserBloc extends Bloc {
+  void load() => notify(); // ok
+}
+
+// Outside library: Bloc().notify(); // warn
+```
+
+or [DartPad Example](https://gist.github.com/tsinis/fb5cb02ccbf114f16c8eb738453cf833)
+
+> [!NOTE]
+> Also prevents calling protected members on other instances outside the library.
+
+---
+
+### @visibleForOverriding (meta)
+
+Why: Public for override, not for direct use. Communicate "hook only".
+
+When: Template method pattern for end‑user subclassing.
+
+```dart
+class Parser {
+  @visibleForOverriding
+  void onToken(String t) {}
+}
+// Users: subclass Parser and override onToken; don't call it directly.
+```
+
+or [DartPad Example](https://gist.github.com/tsinis/223b11ac287876493a03815f704d3796)
+
+> [!TIP]
+> Pair with `@nonVirtual` on siblings you don't want changed to draw a crisp override surface.
+
+---
+
+### @visibleForTesting (meta)
+
+Why: Expose just enough for tests without endorsing production use.
+
+When: Reset hooks, state peeks, determinism toggles.
+
+```dart
+@visibleForTesting
+void resetSingletons() {/*...*/}
+```
+
+or [DartPad Example](https://gist.github.com/tsinis/cb1f9c4311facfbd343ccbaaa61a0ce2)
+
+> [!TIP]
+> Public but "test‑scoped" intent — makes review faster by flagging accidental production calls.
+
+---
+
+## Const & Construction
+
+### @immutable (meta)
+
+Why: Enforce final fields across the hierarchy. Value semantics, safer reuse, easier equality.
+
+When: Value types, Flutter widgets, config objects.
+
+```dart
+@immutable
+class Point {
+  final double x, y;
+  const Point(this.x, this.y);
+}
+```
+
+or [DartPad Example](https://gist.github.com/tsinis/801ff25832dac3ff87027de6276695b1)
+
+> [!NOTE]
+> Subclasses must also be immutable. Mutability can't sneak in lower down.
+
+---
+
+### @literal (meta)
+
+Why: Require const invocation for const constructors when possible. Keep instances canonical.
+
+When: Tokens, interned IDs, const config.
+
+```dart
+class Tag {
+  @literal
+  const Tag(this.name);
+  final String name;
+}
+
+const a = Tag('alpha'); // canonical
+```
+
+or [DartPad Example](https://gist.github.com/tsinis/4e0ca7cc77876bc84d3d958f5bf63eac)
+
+> [!TIP]
+> Prevent accidental runtime allocation of something that should be const.
+
+---
+
+### @optionalTypeArgs (meta)
+
+Why: Allow generic classes to be used without explicit type arguments when strict analysis is enabled.
+
+When: APIs where type inference usually works, avoiding noisy generics at call sites.
+
+```dart
+// Without annotation - triggers strict_raw_type warnings
+class Serializer<T> {
+  String serialize(T data) => data.toString();
+}
+
+@optionalTypeArgs // Allows raw usage even with strict analysis
+class FriendlySerializer<T> {
+  String serialize(T data) => data.toString();
+}
+
+void example() {
+  final strict = Serializer(); // Warning: strict_raw_type
+  final friendly = FriendlySerializer(); // OK
+}
+```
+
+or [DartPad Example](https://gist.github.com/tsinis/867339a96acc4355318ecf331a4f6007)
+
+> [!TIP]
+> Great transitional tool when adding generics to pre‑generic APIs.
+
+---
+
+## Result & Resource Usage
+
+### @awaitNotRequired (meta)
+
+Why: Fire‑and‑forget by design. Suppress unawaited Future lints at call sites.
+
+When: Logging, analytics, background warmups.
+
+```dart
+@awaitNotRequired
+Future<void> log(String message) async {
+  // enqueue in background
+}
+
+void main() {
+  log('hello'); // allowed to drop
+}
+```
+
+or [DartPad Example](https://gist.github.com/tsinis/758cf11dec0ff5cbeff8c14798760f61)
+
+> [!NOTE]
+> You can annotate Future‑typed fields and top‑level variables too, not just functions.
+
+---
+
+### @doNotStore (meta)
+
+Why: Value is ephemeral or sensitive; caching is harmful.
+
+When: Nonces, one‑time tokens, IO handles.
+
+```dart
+// Annotated: the returned value must not be stored (in fields, top-level vars).
+@doNotStore
+String newCsrfToken() => DateTime.now().microsecondsSinceEpoch.toString();
+
+// Non-annotated: a stable identifier that is safe to cache.
+String stableUserId() => 'user-123';
+
+final cachedTokenGood = stableUserId(); // No analyzer warning.
+final cachedTokenWrong = newCsrfToken(); // Warning: assignment_of_do_not_store
+```
+
+or [DartPad Example](https://gist.github.com/tsinis/7e38e8e3246b97d92f7fdef628971a43)
+
+> [!TIP]
+> If a method passes through a `@doNotStore` value, annotate the pass‑through too to keep the contract alive.
+
+---
+
+### @doNotSubmit (meta)
+
+Why: Dev‑only flags and helpers should never land in main.
+
+When: Local experiments, test skips, trace toggles.
+
+```dart
+void test(String name, void Function() body, {@doNotSubmit bool skip = false}) {
+  // ...
+}
+
+void main() {
+  test('ok', () {});
+  test('tmp', () {}, skip: true); // remove before commit
+}
+```
+
+or [DartPad Example](https://gist.github.com/tsinis/cb59d35317b9e0c46f6db863cc3860a8)
+
+> [!NOTE]
+> Useful in CI to catch "forgot to remove debug flag."
+
+---
+
+### @useResult (meta)
+
+Why: Dropping the result is almost always a bug.
+
+When: Validators, transforms, error‑carrying types, builders returning new instances.
+
+```dart
+class Sanitizer {
+  @useResult
+  String cleaned(String s) => s.trim();
+}
+
+void main() {
+  final s = Sanitizer();
+  // s.cleaned(' x '); // warn
+  final c = s.cleaned(' x ');
+}
+```
+
+or [DartPad Example](https://gist.github.com/tsinis/32e3c23f17e7fec603217cfafc431d88)
+
+> [!TIP]
+> Use `UseResult.unless(parameterDefined: 'sink')` to allow "safe to ignore if you provided a sink/callback" patterns.
+
+---
+
+## Testing Aids
+
+### @isTest / @isTestGroup (meta)
+
+Why: Custom test DSLs still get IDE "run" affordances and discovery.
+
+When: Wrapping or extending test frameworks.
+
+```dart
+@isTest
+void it(String name, Future<void> Function() body) => test(name, body);
+
+@isTestGroup
+void describe(String name, void Function() body) => group(name, body);
+```
+
+or [DartPad Example](https://gist.github.com/tsinis/939d4618ae2e54441b09bf6ad2f82805)
+
+> [!NOTE]
+> Keep your expressive DSL and preserve tooling integration.
+
+---
+
+## Experimental & Versioning
+
+### @deprecated (core)
+
+Why: Warn and guide. Keep momentum while users migrate.
+
+When: Replacing or removing APIs.
+
+```dart
+@Deprecated('Use NewApi.v2')
+void oldApi() {}
+```
+
+or [DartPad Example](https://gist.github.com/tsinis/4eea5d99d88ab0408d069b0a37829975)
+
+> [!TIP]
+> Deprecating at the library level cascades to members — one change can cover a broad surface.
+
+---
+
+### @experimental (meta)
+
+Why: Be explicit that this public API might change or vanish.
+
+When: Early designs, preview features.
+
+```dart
+@experimental
+class NewRenderer {/*...*/}
+```
+
+or [DartPad Example](https://gist.github.com/tsinis/fd0e5f061a7210747ca92fe516a725e3)
+
+> [!NOTE]
+> Combine with `@internal` to keep experiments visible inside your package without committing publicly.
+
+---
+
+### @reopen (meta)
+
+Why: Intentionally reopen inheritance where lints would complain. Document the intent.
+
+When: Generated code, staged API stabilization.
+
+```dart
+@reopen
+class Extensible {}
+```
+
+or [DartPad Example](https://gist.github.com/tsinis/608851aa60a21e96cc87b533fb2ef59e)
+
+> [!TIP]
+> Useful when accepting constraints from superinterfaces but still allowing downstream extension.
+
+---
+
+## Performance & Tooling Pragmas
+
+### @RecordUse (meta, experimental)
+
+Why: Record statically resolved invocations for post‑compile tooling and analysis.
+
+When: Build‑time analytics, codegen, instrumentation.
+
+```dart
+@RecordUse()
+void tracked() {/*...*/}
+// Calls to tracked() are recorded for tooling steps.
+```
+
+or [DartPad Example](https://gist.github.com/tsinis/38dfa4dc5270374262398a0596c69c7e)
+
+> [!NOTE]
+> Can be combined with `@mustBeConst` on select parameters to keep post‑compile data const‑safe.
+
+---
+
+### @pragma (core)
+
+Why: Toolchain hint for the VM/compiler. Use only when you know the exact pragma and its implications.
+
+When: VM entry points, interop boundaries, perf tuning.
+
+```dart
+@pragma('vm:entry-point')
+void keepMe() {}
+```
+
+or [DartPad Example](https://gist.github.com/tsinis/d818a6c9e4bba7f8305db85b6ee4f42e)
+
+> [!WARNING]
+> Pragmas are not general API annotations; they're instructions to specific tools/runtimes. For a deeper tour of VM pragmas, see Dart VM-Specific Pragma Annotations (mrale.ph) , and the general metadata overview on dart.dev .
+
+---
+
+## Bonus: Dart Code Metrics Annotations
+
+### @Throws (DCM)
+
+Why: Make throwing behavior explicit. Call sites must handle declared exceptions; declarations should truthfully advertise throws.
+
+When: Public APIs that can throw (parsers, IO, validation) and you want consumers to catch or propagate deliberately.
+
+```dart
+@Throws({FormatException})
+int parsePort(String env) {
+  if (env.isEmpty) throw const FormatException('PORT is empty');
+  return int.parse(env);
+}
+```
+
+> [!NOTE]
+> With DCM enabled, unhandled invocations of `@Throws` APIs are flagged, and throwers not annotated are suggested to add `@Throws`.
+
+---
+
+### @AcceptedTypes (DCM)
+
+Why: Document and enforce allowed runtime types when a field/parameter is typed as `Object`.
+
+When: Bridging dynamic sources (JSON, message channels, env/config) where only a safe subset of types is valid.
+
+```dart
+void logValue(@AcceptedTypes({String, int}) Object value) {}
+logValue(true); // flagged by DCM
+```
+
+> [!TIP]
+> Prefer precise static types when possible; use `@AcceptedTypes` only for unavoidable `Object` surfaces.
+
+---
+
+## Overriding Annotations Compared
+
+For quick decision‑making:
+
+| Annotation       | Intent                             | Analyzer behavior         | Typical use                          |
+| ---------------- | ---------------------------------- | ------------------------- | ------------------------------------ |
+| mustCallSuper    | Overrides must call super          | Warns if super not called | Lifecycle (init/dispose), invariants |
+| mustBeOverridden | Concrete subclasses must implement | Error if missing          | Framework hooks, contracts           |
+| nonVirtual       | Disallow overriding                | Error on override attempt | Lock invariants, equality            |
+
+---
+
+## Wrap‑up and next steps
+
+Annotations are tiny but powerful. They turn implicit intentions into explicit contracts, and enlist the analyzer and tooling to keep your codebase honest during refactors. If you're new to Dart, start by consistently using `@override`, `@immutable`, and `@deprecated`. As your codebase grows, layer in `@mustCallSuper`, `@useResult`, `@protected`, and `@visibleForTesting` to make APIs safer and clearer. Reach for pragmas sparingly and deliberately.
+
+Further reading if you want the official details:
+
+- Metadata | Dart: <https://dart.dev/language/metadata>
+- Dart VM-Specific Pragma Annotations: <https://mrale.ph/dartvm/pragmas.html>
+
+## How to check those examples locally?
+
+Some examples rely on analyzer and linter behavior that DartPad doesn't support (custom `analysis_options.yaml`, DCM rules, stricter inference). To see all the warnings/hints the cheat sheet talks about, run it in your IDE.
+Clone this project and enter it:
+
+```shell
+git clone https://github.com/tsinis/tips-and-tricks
+cd tips-and-tricks/dart/annotations-cheat-sheet
+dart pub get
+```
+
+Open in your IDE (e.g., VS Code):
+
+```shell
+code .
+```
+
+Analyze/Run any example file:
+
+```shell
+dart analyze lib/factory.dart
+dart run lib/throws.dart
+```

--- a/dart/annotations-cheat-sheet/analysis_options.yaml
+++ b/dart/annotations-cheat-sheet/analysis_options.yaml
@@ -1,0 +1,30 @@
+include: package:lints/recommended.yaml
+
+analyzer:
+  language:
+    # Flag uses of generic types without explicit type arguments ("raw types").
+    # @optionalTypeArgs on a declaration explicitly allows omitting type args.
+    strict-raw-types: true
+    # Tighten inference to avoid implicit dynamic creeping in unrelated examples.
+    strict-inference: true
+
+linter:
+  rules:
+    # Powers @awaitNotRequired demo: warns when a Future's result is discarded
+    # (not awaited/handled). Suppressed by @awaitNotRequired.
+    discarded_futures: true
+    # Powers @reopen demo: warns when a subclass implicitly reopens a restricted
+    # supertype by not having a restrictive modifier. Suppressed by @reopen.
+    implicit_reopen: true
+
+dart_code_metrics:
+  rules:
+    # Powers @Throws demo: warns when a function that can throw is not annotated
+    # with @Throws, or when an annotated function does not throw. Suppressed by
+    # @Throws.
+    - handle-throwing-invocations: true
+    - prefer-correct-throws: true
+
+    # Powers @AcceptedTypes demo: warns when a function is called with arguments
+    # of types not listed in its @AcceptedTypes annotation. Suppressed by @AcceptedTypes.
+    - pass-correct-accepted-type: true

--- a/dart/annotations-cheat-sheet/lib/accepted_types.dart
+++ b/dart/annotations-cheat-sheet/lib/accepted_types.dart
@@ -1,0 +1,13 @@
+import 'package:dart_code_metrics_annotations/annotations.dart';
+
+/// Only accepts [String] or [int] for a "retry" config value.
+void applyRetry(@AcceptedTypes({String, int}) Object value) => print(value);
+
+/// Unrestricted metadata value (no annotation, any [Object] is allowed).
+void applyTag(Object value) => print(value);
+
+void main() {
+  applyTag(true); // No annotation, no warning...
+  applyRetry(true); // Warning: pass-correct-accepted-type
+  applyRetry(3); // No warning here, proper type provided.
+}

--- a/dart/annotations-cheat-sheet/lib/await_not_required.dart
+++ b/dart/annotations-cheat-sheet/lib/await_not_required.dart
@@ -1,0 +1,22 @@
+import 'dart:async';
+import 'package:meta/meta.dart';
+
+/// Non-annotated: callers should await or otherwise handle the [Future].
+Future<void> writeAuditLog(String message) async {
+  await Future<void>.delayed(const Duration(milliseconds: 10));
+  print('[audit] $message');
+}
+
+/// Annotated: explicitly fire-and-forget. Callers can drop the Future.
+@awaitNotRequired
+Future<void> queueTelemetry(String event) async {
+  await Future<void>.delayed(const Duration(milliseconds: 5));
+  print('[telemetry] $event');
+}
+
+void main() {
+  writeAuditLog('user signed in'); // Analyzer warning for discarded future.
+  queueTelemetry('session-started'); // OK due to @awaitNotRequired.
+  unawaited(writeAuditLog('user signed in and awaited')); // Explicitly handle.
+  // In production code prefer: await writeAuditLog(...); here we keep main sync.
+}

--- a/dart/annotations-cheat-sheet/lib/deprecated.dart
+++ b/dart/annotations-cheat-sheet/lib/deprecated.dart
@@ -1,0 +1,13 @@
+/// Old API; use `hashV2` instead.
+@Deprecated('Use hashV2')
+int hashV1(String input) => input.hashCode;
+
+/// Replacement API with clearer semantics.
+int hashV2(String input) => Object.hashAllUnordered([input, 0xC0DE]);
+
+void main() {
+  // Deprecated: analyzer warns with the deprecation message.
+  final a = hashV1('abc'); // Analyzer: deprecated_member_use_from_same_package
+  final b = hashV2('abc'); // Preferred: no warning.
+  print({'v1': a, 'v2': b}); // Keep program runnable.
+}

--- a/dart/annotations-cheat-sheet/lib/do_not_store.dart
+++ b/dart/annotations-cheat-sheet/lib/do_not_store.dart
@@ -1,0 +1,16 @@
+import 'package:meta/meta.dart';
+
+/// Annotated: the returned value must not be stored (in fields, top-level vars).
+@doNotStore
+String newCsrfToken() => DateTime.now().microsecondsSinceEpoch.toString();
+
+// Non-annotated: a stable identifier that is safe to cache.
+String stableUserId() => 'user-123';
+
+final cachedTokenGood = stableUserId(); // No analyzer warning.
+final cachedTokenWrong = newCsrfToken(); // Has analyzer warning.
+
+void main() {
+  print('stable id cached: $cachedTokenGood');
+  print('ephemeral id cached: $cachedTokenWrong');
+}

--- a/dart/annotations-cheat-sheet/lib/do_not_submit.dart
+++ b/dart/annotations-cheat-sheet/lib/do_not_submit.dart
@@ -1,0 +1,19 @@
+import 'package:meta/meta.dart';
+
+/// Regular helper with an opt-in skip for local runs (safe to commit).
+void bench(String name, {bool skip = false}) {
+  if (!skip) print('[bench] $name');
+}
+
+/// The skip flag is dev-only and should not land in source control.
+void spec(String name, {@doNotSubmit bool skip = false}) {
+  if (!skip) print('[spec] $name');
+}
+
+void main() {
+  // Unannotated: allowed to keep skip=true in source (no diagnostic).
+  bench('baseline-throughput', skip: true);
+
+  // Annotated: analyzer flags this dev-only toggle to remove before commit.
+  spec('wip-scenario', skip: true); // ! invalid_use_of_do_not_submit_member !
+}

--- a/dart/annotations-cheat-sheet/lib/experimental.dart
+++ b/dart/annotations-cheat-sheet/lib/experimental.dart
@@ -1,0 +1,33 @@
+import 'package:meta/meta.dart';
+
+/// Stable HTTP client for production use.
+class HttpClient {
+  Future<String> get(String url) async => 'response from $url';
+}
+
+/// Preview feature; may break without version bump. Tools can warn when used
+/// from external packages that haven't opted into experimental APIs.
+@experimental
+class Http3Client {
+  Future<String> get(String url) async => 'http3 response from $url';
+}
+
+/// Simulated external library usage.
+class WebFramework {
+  static void registerClient(Object client) {
+    print('Registered: ${client.runtimeType}');
+  }
+}
+
+void main() {
+  // Stable: safe for production use.
+  final stableClient = HttpClient();
+  WebFramework.registerClient(stableClient);
+
+  // Experimental: no warning here (same package), but external packages
+  // using this would see analyzer warnings unless they opt into experimental APIs.
+  final experimentalClient = Http3Client();
+  WebFramework.registerClient(experimentalClient);
+
+  print('Both clients registered successfully');
+}

--- a/dart/annotations-cheat-sheet/lib/factory.dart
+++ b/dart/annotations-cheat-sheet/lib/factory.dart
@@ -1,0 +1,30 @@
+import 'package:meta/meta.dart';
+
+class Logger {
+  const Logger(this.destination);
+  final String destination;
+}
+
+class LoggerFactory {
+  @factory // Always returns a new [Logger] instance (not a cached singleton).
+  static Logger createLogger(String destination) => Logger(destination);
+}
+
+class LoggerCache {
+  static final Map<int, Logger> _cache = {};
+
+  @factory // Analyzer error: Factory doesn't return a newly allocated [Logger].
+  static Logger createLogger(String destination) =>
+      _cache.putIfAbsent(destination.length, () => Logger(destination));
+}
+
+void main() {
+  final logger1 = LoggerFactory.createLogger('1');
+  final logger2 = LoggerCache.createLogger('2');
+  print('Logger1 destination: ${logger1.destination}'); // Prints 1
+  print('Logger2 destination: ${logger2.destination}'); // Prints 2
+  final logger3 = LoggerFactory.createLogger('3');
+  final logger4 = LoggerCache.createLogger('4');
+  print('Logger3 destination: ${logger3.destination}'); // Prints 3
+  print('Logger4 destination: ${logger4.destination}'); // Prints 2
+}

--- a/dart/annotations-cheat-sheet/lib/immutable.dart
+++ b/dart/annotations-cheat-sheet/lib/immutable.dart
@@ -1,0 +1,29 @@
+import 'package:meta/meta.dart';
+
+@immutable
+base class Point {
+  const Point(this.x, this.y);
+  final double x, y;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is Point && other.x == x && other.y == y;
+  }
+
+  @override
+  int get hashCode => Object.hash(x, y);
+}
+
+/// Analyzer error: must_be_immutable!
+final class MutablePoint extends Point {
+  MutablePoint(super.x, super.y, [this.z]);
+  double? z;
+}
+
+void main() {
+  final a = MutablePoint(1, 2, 3); // Cannot be assigned as a constant.
+  const b = Point(1, 2);
+  print(a == b); // true, value semantics.
+  a.z = 5; // Not possible in an immutable class.
+}

--- a/dart/annotations-cheat-sheet/lib/internal.dart
+++ b/dart/annotations-cheat-sheet/lib/internal.dart
@@ -1,0 +1,17 @@
+import 'package:meta/meta.dart';
+
+export 'internal.dart' show Helper; // Warning: internal class can't be exported
+
+class PublicApi {
+  void perform() => Helper().foo();
+}
+
+void main() {
+  PublicApi().perform();
+  Helper().foo(); // Shows warning in IDE, if used outside using class directly.
+}
+
+@internal // ignore: invalid_internal_annotation, just an example.
+class Helper {
+  void foo() => print('Doing internal work');
+}

--- a/dart/annotations-cheat-sheet/lib/is_test.dart
+++ b/dart/annotations-cheat-sheet/lib/is_test.dart
@@ -1,0 +1,33 @@
+import 'dart:async';
+
+import 'package:meta/meta.dart';
+
+/// Test DSL wrapper recognized by IDE as a test entry point.
+/// In a real project, delegate to `test(name, body)` from package:test.
+@isTest
+void it(String name, Future<void> Function() body) => body();
+
+/// Group wrapper recognized by IDE as a test group.
+/// In a real project, delegate to `group(name, body)` from package:test.
+@isTestGroup
+void describe(String name, void Function() body) => body();
+
+// Unannotated counterparts (plain functions; no special test discovery/run icons).
+void itRaw(String name, Future<void> Function() body) => body();
+void describeRaw(String name, void Function() body) => body();
+
+void main() {
+  // Annotated: IDE shows test run affordances and discovery here.
+  describe('sanitizer', () {
+    it('trims', () async {
+      // test body
+    });
+  });
+
+  // Unannotated: plain functions; no test run affordances here.
+  describeRaw('sanitizer-raw', () {
+    itRaw('trims-raw', () async {
+      // test body
+    });
+  });
+}

--- a/dart/annotations-cheat-sheet/lib/literal.dart
+++ b/dart/annotations-cheat-sheet/lib/literal.dart
@@ -1,0 +1,24 @@
+import 'package:meta/meta.dart';
+
+class Tag {
+  const Tag(this.name); // Regular constructor.
+  @literal
+  const Tag.literal(this.name); // Literal constructor.
+
+  final String name;
+}
+
+void main() {
+  // Using the @literal constructor: must use const.
+  const tagA = Tag.literal('alpha');
+  const tagB = Tag.literal('alpha');
+  print('literal: identical(tagA, tagB): ${identical(tagA, tagB)}'); // true
+
+  // Using the regular const constructor: can use const or not.
+  const tagC = Tag('beta');
+  final tagD = Tag('beta');
+  print('regular: identical(tagC, tagD): ${identical(tagC, tagD)}'); // false
+
+  // Tag below will cause analyzer error: must use const with @literal
+  final tagE = Tag.literal('gamma');
+}

--- a/dart/annotations-cheat-sheet/lib/must_be_const.dart
+++ b/dart/annotations-cheat-sheet/lib/must_be_const.dart
@@ -1,0 +1,24 @@
+import 'package:meta/meta.dart';
+
+class FeatureFlag {
+  const FeatureFlag(this.value);
+  final int value;
+}
+
+/// Only compile-time constant 'b' is allowed for comparison.
+bool areFlagsEqual(FeatureFlag a, @mustBeConst FeatureFlag b) => a == b;
+
+const flagA = FeatureFlag(1);
+const flagB = FeatureFlag(1);
+var flagC = FeatureFlag(flagA.value); // NOT const.
+
+void main() {
+  // This is OK: both are constants.
+  print('flagA == flagB: ${areFlagsEqual(flagA, flagB)}');
+
+  // This will cause analyzer warning: 'flagC' is not const.
+  print('flagA == flagC: ${areFlagsEqual(flagA, flagC)}');
+
+  // Real difference: @mustBeConst ensures only canonical, compile-time objects
+  // are compared preventing subtle bugs from runtime-generated values.
+}

--- a/dart/annotations-cheat-sheet/lib/must_be_overridden.dart
+++ b/dart/annotations-cheat-sheet/lib/must_be_overridden.dart
@@ -1,0 +1,28 @@
+import 'package:meta/meta.dart';
+
+base class PaymentMethod {
+  @mustBeOverridden
+  bool validatePayment(double amount) => amount > 0;
+
+  void process(double amount) {
+    if (!validatePayment(amount)) throw Exception('Payment validation failed!');
+    print('Processing payment of $amount');
+  }
+}
+
+final class CreditCardPayment extends PaymentMethod {
+  @override
+  bool validatePayment(double amount) =>
+      super.validatePayment(amount) && amount < 100_000; // Can use super.
+}
+
+// Analyzer error: Missing concrete implementation of 'validatePayment'.
+final class CashPayment extends PaymentMethod {}
+
+// The analyzer will require every concrete subclass of PaymentMethod
+// to implement validatePayment, enforcing correct framework usage.
+void main() {
+  final payment = CreditCardPayment();
+  print(payment.validatePayment(-1)); // Uses super check but needs override.
+  payment.process(100); // OK
+}

--- a/dart/annotations-cheat-sheet/lib/must_call_super.dart
+++ b/dart/annotations-cheat-sheet/lib/must_call_super.dart
@@ -1,0 +1,19 @@
+import 'package:meta/meta.dart';
+
+class DatabaseConnection {
+  @mustCallSuper
+  void open() => print('Opening base database connection...');
+}
+
+class LoggingDatabaseConnection extends DatabaseConnection {
+  @override
+  void open() {
+    // Uncommenting the next line will fix the analyzer warning:
+    // super.open();
+    print('Opening database connection with logging...');
+  }
+}
+
+void main() => LoggingDatabaseConnection().open();
+// The analyzer will warn that LoggingDatabaseConnection.open()
+// does not call super.open(), violating the @mustCallSuper contract.

--- a/dart/annotations-cheat-sheet/lib/non_virtual.dart
+++ b/dart/annotations-cheat-sheet/lib/non_virtual.dart
@@ -1,0 +1,30 @@
+import 'package:meta/meta.dart';
+
+class Entity {
+  const Entity(this._id);
+
+  @nonVirtual
+  int get schemaVersion => 3;
+
+  bool get isPersisted => _id != null;
+  final int? _id;
+}
+
+class User extends Entity {
+  const User(this.name, [super._id]);
+
+  @override // Analyzer error: Cannot override non-virtual member.
+  int get schemaVersion => 4;
+
+  final String name;
+}
+
+void main() {
+  final user = User('Alice', 42);
+  print('User persisted: ${user.isPersisted}'); // true
+  print('User schema version: ${user.schemaVersion}'); // 4
+
+  final user2 = Entity(null);
+  print('User2 persisted: ${user2.isPersisted}'); // false
+  print('User2 schema version: ${user2.schemaVersion}'); // 3
+}

--- a/dart/annotations-cheat-sheet/lib/optional_type_args.dart
+++ b/dart/annotations-cheat-sheet/lib/optional_type_args.dart
@@ -1,0 +1,44 @@
+import 'package:meta/meta.dart';
+
+/// Generic serializer used by small tools/tests to parse inputs.
+class Serializer<T> {
+  const Serializer(this.parse);
+  final T Function(Object? input) parse;
+}
+
+/// Same API, but callers may omit type arguments anywhere it's referenced.
+@optionalTypeArgs
+class FriendlySerializer<T> {
+  const FriendlySerializer(this.parse);
+  final T Function(Object? input) parse;
+}
+
+int parsePort(Object? v) => int.parse(v.toString());
+
+// Non-annotated: returning a raw generic type is flagged by analyzer when
+// strict-raw-types is enabled.
+Serializer makeRawSerializer() => Serializer((v) => v.toString());
+
+void main() {
+  // Non-annotated (shows analyzer warning on the variable type).
+  Serializer rawS = Serializer((v) => v.toString());
+
+  // Annotated (allowed to omit <T> on both sides):
+  FriendlySerializer rawF = FriendlySerializer((v) => v.toString());
+
+  // Typical explicit-typed usage still works for both:
+  final portS = Serializer<int>(parsePort);
+  final portF = FriendlySerializer<int>(parsePort);
+
+  final stringS = Serializer<String>((v) => v.toString());
+  print(stringS.parse(123)); // "123"
+  print(rawF.parse('456')); // "456"
+  print(portS.parse('8080')); // 8080
+  print(portF.parse('3000')); // 3000
+
+  // Inference on the annotated version at the call site:
+  final inferredF = FriendlySerializer(
+    (v) => (v as Map<String, String>)['PORT'] ?? '',
+  );
+  print(inferredF.parse({'PORT': '9090'}));
+}

--- a/dart/annotations-cheat-sheet/lib/override.dart
+++ b/dart/annotations-cheat-sheet/lib/override.dart
@@ -1,0 +1,22 @@
+class NotificationService {
+  void send(String message) => print('Sending generic notification: $message');
+}
+
+class EmailNotificationService extends NotificationService {
+  @override // Proper method override, no issues here.
+  void send(String message) => print('Sending email: $message');
+}
+
+class SmsNotificationService extends NotificationService {
+  @override // The method doesn't override an inherited method!
+  void sends(String message) => print('Sending SMS: $message');
+}
+
+void main() {
+  final services = [EmailNotificationService(), SmsNotificationService()];
+  for (var service in services) {
+    service.send('Your order has shipped!');
+  }
+  // [SmsNotificationService] will not be able to override the send method,
+  // providing only generic notification.
+}

--- a/dart/annotations-cheat-sheet/lib/pragma.dart
+++ b/dart/annotations-cheat-sheet/lib/pragma.dart
@@ -1,0 +1,45 @@
+// Dart VM pragmas are toolchain hints. They do not usually produce analyzer
+// warnings; they influence JIT/AOT compilers and tree-shaking.
+
+// Keep this symbol reachable in AOT (tree-shaken) builds, even if it appears
+// unused to the compiler (for example, called from native/FFI or reflection).
+@pragma('vm:entry-point')
+void keepDuringTreeShaking() {
+  // FFI/platform code may call into this. The pragma prevents its removal.
+}
+
+class Service {
+  // Mark a constructor as an entry point if it can be constructed via native
+  // code or reflection. Without this, AOT might remove it as "unused".
+  @pragma('vm:entry-point')
+  Service._();
+
+  static Service create() => Service._();
+}
+
+// Hint to the VM that this tiny function is a good candidate for inlining in
+// optimized (release/AOT) builds. Inlining can reduce call overhead.
+@pragma('vm:prefer-inline')
+int clampToByte(int value) {
+  if (value < 0) return 0;
+  if (value > 255) return 255;
+  return value;
+}
+
+// Conversely, prevent inlining to keep a clear stack frame (useful for
+// profiling or to avoid code bloat when the function is large).
+@pragma('vm:never-inline')
+String computeTag(int id) => 'item_$id';
+
+void main() {
+  // Using the functions normally; analyzer does not warn about pragmas.
+  keepDuringTreeShaking();
+  final svc = Service.create();
+  final a = clampToByte(300);
+  final b = computeTag(a);
+  // Touch values to avoid "unused" lints in examples.
+  if (svc.hashCode == 0) {
+    // This branch is never true; it just keeps variables "used".
+    print(b);
+  }
+}

--- a/dart/annotations-cheat-sheet/lib/protected.dart
+++ b/dart/annotations-cheat-sheet/lib/protected.dart
@@ -1,0 +1,26 @@
+import 'package:meta/meta.dart';
+
+class BankAccount {
+  BankAccount(this._balance);
+  double _balance;
+
+  @protected
+  void applyFee(double fee) => _balance -= fee;
+
+  double get balance => _balance;
+}
+
+class PremiumAccount extends BankAccount {
+  PremiumAccount(super.initial);
+
+  /// Allowed: subclass can call protected method
+  void monthlyMaintenance() => applyFee(5);
+}
+
+void main() {
+  final account = PremiumAccount(100);
+  account.monthlyMaintenance();
+  print('Balance after fee: ${account.balance}');
+  // Not allowed: protected method is not accessible outside the class hierarchy.
+  account.applyFee(10); // Show a warning in IDEs (when used outside the file).
+}

--- a/dart/annotations-cheat-sheet/lib/record_use.dart
+++ b/dart/annotations-cheat-sheet/lib/record_use.dart
@@ -1,0 +1,17 @@
+import 'package:meta/meta.dart';
+
+/// Calls are recorded for post-compile tooling.
+@RecordUse()
+void auditLog(String message, {String level = 'info'}) {
+  // No-op in this demo.
+}
+
+/// Regular function; calls are not recorded.
+void debugLog(String message, {String level = 'info'}) {
+  // No-op in this demo.
+}
+
+void main() {
+  auditLog('app started'); // Recorded.
+  debugLog('app started'); // Not recorded.
+}

--- a/dart/annotations-cheat-sheet/lib/redeclare.dart
+++ b/dart/annotations-cheat-sheet/lib/redeclare.dart
@@ -1,0 +1,21 @@
+import 'package:meta/meta.dart';
+
+/// Extension type for non-negative integers (e.g., for car mileage, age, etc.).
+extension type const NonNegativeInt(int value) implements int {
+  @redeclare
+  int operator -(int other) {
+    final result = value - other;
+    assert(!result.isNegative, 'Result cannot be negative!');
+
+    return result;
+  }
+}
+
+void main() {
+  const balance = NonNegativeInt(100);
+  const withdrawal = NonNegativeInt(300);
+
+  // This will throw an assertion error in debug mode:
+  final newBalance = balance - withdrawal;
+  print('New balance: $newBalance');
+}

--- a/dart/annotations-cheat-sheet/lib/reopen.dart
+++ b/dart/annotations-cheat-sheet/lib/reopen.dart
@@ -1,0 +1,22 @@
+import 'package:meta/meta.dart';
+
+/// A restricted supertype: external libraries may implement but may not extend.
+interface class ApiService {
+  void ping() => print('pong');
+}
+
+/// Intentional reopen: suppresses the `implicit_reopen` lint for this subclass.
+@reopen
+class OpenSubReopened extends ApiService {}
+
+/// LINT: This subclass implicitly reopens [ApiService] for extension outside the
+/// library because it lacks a restricting modifier. Triggers `implicit_reopen`.
+class OpenSub extends ApiService {}
+
+void main() {
+  ApiService a = OpenSub();
+  a.ping();
+
+  ApiService b = OpenSubReopened();
+  b.ping();
+}

--- a/dart/annotations-cheat-sheet/lib/throws.dart
+++ b/dart/annotations-cheat-sheet/lib/throws.dart
@@ -1,0 +1,22 @@
+import 'package:dart_code_metrics_annotations/annotations.dart';
+
+/// Parses the PORT env value. Throws [FormatException] when empty or invalid.
+@Throws({FormatException})
+int readPort(String env) {
+  if (env.isEmpty) throw const FormatException('PORT is empty');
+  return int.parse(env);
+}
+
+/// Throws but not annotated; DCM will suggest adding [@Throws].
+int readTimeout(String env) {
+  if (env.isEmpty) throw const FormatException('TIMEOUT is empty');
+  return int.parse(env);
+}
+
+void main() {
+  readTimeout(''); // No annotation, no warning... But with runtime exception!
+  readPort(''); // Also exception, but with warning: handle-throwing-invocations
+  try {
+    readPort('8080'); // No warning here, correctly handled.
+  } catch (_) {}
+}

--- a/dart/annotations-cheat-sheet/lib/use_result.dart
+++ b/dart/annotations-cheat-sheet/lib/use_result.dart
@@ -1,0 +1,21 @@
+import 'package:meta/meta.dart';
+
+class Sanitizer {
+  /// Return a cleaned string; the result must be used by callers.
+  @useResult
+  String cleaned(String s) => s.trim();
+
+  /// Non-annotated transform; ignoring the result is allowed.
+  String uppercased(String s) => s.toUpperCase();
+}
+
+void main() {
+  final sanitizer = Sanitizer();
+  // Annotated: ignoring the result is flagged by the analyzer.
+  sanitizer.cleaned('  keep me  '); // ! Analyzer: unused_result
+  // Non-annotated: ignoring the result is allowed.
+  sanitizer.uppercased('ignore me');
+  // Proper usage: capture and use the cleaned value.
+  final c = sanitizer.cleaned('  x  ');
+  print('[$c]');
+}

--- a/dart/annotations-cheat-sheet/lib/visible_for_overriding.dart
+++ b/dart/annotations-cheat-sheet/lib/visible_for_overriding.dart
@@ -1,0 +1,25 @@
+import 'package:meta/meta.dart';
+
+class DataProcessor {
+  @visibleForOverriding
+  void onData(String data) {
+    // Intended for override, not for direct calls
+  }
+
+  void process(String data) {
+    // ... some processing logic ...
+    onData(data);
+  }
+}
+
+class CustomProcessor extends DataProcessor {
+  @override
+  void onData(String data) => print('Custom processed: $data');
+}
+
+void main() {
+  final processor = CustomProcessor();
+  processor.process('Hello'); // Calls overridden onData.
+  /// Not recommended: direct call to onData:
+  processor.onData('!'); // Show a warning in IDEs (when used outside the file).
+}

--- a/dart/annotations-cheat-sheet/lib/visible_for_testing.dart
+++ b/dart/annotations-cheat-sheet/lib/visible_for_testing.dart
@@ -1,0 +1,19 @@
+import 'package:meta/meta.dart';
+
+class ConfigManager {
+  int _counter = 0;
+
+  void increment() => _counter++;
+  int get counter => _counter;
+
+  @visibleForTesting
+  void reset() => _counter = 0;
+}
+
+void main() {
+  final config = ConfigManager();
+  config.increment();
+  print('Counter: ${config.counter}');
+  // Not for production: only for tests
+  config.reset(); // IDE warns if used outside test (when used outside the file)
+}

--- a/dart/annotations-cheat-sheet/pubspec.yaml
+++ b/dart/annotations-cheat-sheet/pubspec.yaml
@@ -1,0 +1,14 @@
+name: annotations_cheat_sheet
+description: A Dart annotations cheat sheet
+version: 1.0.0
+
+environment:
+  sdk: ^3.9.0
+
+dependencies:
+  dart_code_metrics_annotations: ^1.1.0
+  dart_code_metrics_presets: ^2.25.1
+  meta: ^1.17.0
+
+dev_dependencies:
+  lints: ^6.0.0


### PR DESCRIPTION
- Created analysis_options.yaml to include recommended lints and analyzer settings.
- Implemented examples demonstrating the use of annotations such as
```
@AcceptedTypes, @awaitNotRequired, @Deprecated, @doNotStore, @doNotSubmit, @experimental, @factory, @immutable, @internal, @isTest, @literal, @mustBeConst, @mustBeOverridden, @mustCallSuper, @nonVirtual, @optionalTypeArgs, @override, @pragma, @protected, @recordUse, @redeclare, @reopen, @Throws, @useResult, @visibleForOverriding, and @visibleForTesting
```
- Added `pubspec.yaml` to define project metadata and dependencies.