### PR TITLE
Format code in github/git-tips/

### DIFF
--- a/github/git-tips/lib/main.dart
+++ b/github/git-tips/lib/main.dart
@@ -1,19 +1,26 @@
 /// Returns the category name for an HTTP status code.
 String statusCategory(int code) {
-  if (code >= 100 && code < 200) return 'Informational';
-  if (code >= 200 && code < 300) return 'Success';
-  if (code >= 300 && code <= 400) return 'Redirection';
-  if (code > 400 && code < 500) return 'Client Error';
-  if (code >= 500 && code < 600) return 'Server Error';
+  if (code >= 100 && code < 200)
+    return 'Informational';
+  if (code >= 200 && code < 300)
+    return 'Success';
+  if (code >= 300 && code <= 400)
+    return 'Redirection';
+  if (code > 400 && code < 500)
+    return 'Client Error';
+  if (code >= 500 && code < 600)
+    return 'Server Error';
 
   return 'Unknown';
 }
 
 /// Returns true if the status code indicates success (2xx).
-bool isSuccess(int code) => statusCategory(code) == 'Success';
+bool isSuccess(int code) =>
+    statusCategory(code) == 'Success';
 
 /// Returns the standard reason phrase for common HTTP status codes.
-String reasonPhrase(int code) => switch (code) {
+String reasonPhrase(int code) =>
+    switch (code) {
       200 => 'OK',
       201 => 'Created',
       204 => 'No Content',

--- a/github/git-tips/test/main_test.dart
+++ b/github/git-tips/test/main_test.dart
@@ -3,58 +3,135 @@ import 'package:test/test.dart';
 
 void main() {
   group('statusCategory', () {
-    test('returns Informational for 1xx', () {
-      expect(statusCategory(100), equals('Informational'));
-      expect(statusCategory(101), equals('Informational'));
-    });
+    test(
+      'returns Informational for 1xx',
+      () {
+        expect(
+          statusCategory(100),
+          equals('Informational'),
+        );
+        expect(
+          statusCategory(101),
+          equals('Informational'),
+        );
+      },
+    );
 
     test('returns Success for 2xx', () {
-      expect(statusCategory(200), equals('Success'));
-      expect(statusCategory(204), equals('Success'));
+      expect(
+        statusCategory(200),
+        equals('Success'),
+      );
+      expect(
+        statusCategory(204),
+        equals('Success'),
+      );
     });
 
-    test('returns Redirection for 3xx', () {
-      expect(statusCategory(301), equals('Redirection'));
-      expect(statusCategory(304), equals('Redirection'));
-    });
+    test(
+      'returns Redirection for 3xx',
+      () {
+        expect(
+          statusCategory(301),
+          equals('Redirection'),
+        );
+        expect(
+          statusCategory(304),
+          equals('Redirection'),
+        );
+      },
+    );
 
-    test('returns Client Error for 4xx', () {
-      expect(statusCategory(400), equals('Client Error'));
-      expect(statusCategory(404), equals('Client Error'));
-    });
+    test(
+      'returns Client Error for 4xx',
+      () {
+        expect(
+          statusCategory(400),
+          equals('Client Error'),
+        );
+        expect(
+          statusCategory(404),
+          equals('Client Error'),
+        );
+      },
+    );
 
-    test('returns Server Error for 5xx', () {
-      expect(statusCategory(500), equals('Server Error'));
-      expect(statusCategory(503), equals('Server Error'));
-    });
+    test(
+      'returns Server Error for 5xx',
+      () {
+        expect(
+          statusCategory(500),
+          equals('Server Error'),
+        );
+        expect(
+          statusCategory(503),
+          equals('Server Error'),
+        );
+      },
+    );
 
-    test('returns Unknown for out-of-range codes', () {
-      expect(statusCategory(99), equals('Unknown'));
-      expect(statusCategory(600), equals('Unknown'));
-    });
+    test(
+      'returns Unknown for out-of-range codes',
+      () {
+        expect(
+          statusCategory(99),
+          equals('Unknown'),
+        );
+        expect(
+          statusCategory(600),
+          equals('Unknown'),
+        );
+      },
+    );
   });
 
   group('isSuccess', () {
-    test('returns true for 2xx codes', () {
-      expect(isSuccess(200), isTrue);
-      expect(isSuccess(201), isTrue);
-    });
+    test(
+      'returns true for 2xx codes',
+      () {
+        expect(isSuccess(200), isTrue);
+        expect(isSuccess(201), isTrue);
+      },
+    );
 
-    test('returns false for non-2xx codes', () {
-      expect(isSuccess(404), isFalse);
-      expect(isSuccess(500), isFalse);
-    });
+    test(
+      'returns false for non-2xx codes',
+      () {
+        expect(isSuccess(404), isFalse);
+        expect(isSuccess(500), isFalse);
+      },
+    );
   });
 
   group('reasonPhrase', () {
-    test('returns correct phrase for known codes', () {
-      expect(reasonPhrase(200), equals('OK'));
-      expect(reasonPhrase(404), equals('Not Found'));
-      expect(reasonPhrase(500), equals('Internal Server Error'));
-    });
+    test(
+      'returns correct phrase for known codes',
+      () {
+        expect(
+          reasonPhrase(200),
+          equals('OK'),
+        );
+        expect(
+          reasonPhrase(404),
+          equals('Not Found'),
+        );
+        expect(
+          reasonPhrase(500),
+          equals(
+            'Internal Server Error',
+          ),
+        );
+      },
+    );
 
-    test('returns Unknown for unrecognized codes', () {
-      expect(reasonPhrase(418), equals('Unknown'));
-    });
+    test(
+      'returns Unknown for unrecognized codes',
+      () {
+        expect(
+          reasonPhrase(418),
+          equals('Unknown'),
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
Formatted the Dart code in the `github/git-tips/` project as requested. The formatting is compliant with the project's specific `analysis_options.yaml` (which uses a 40-character page width). I also verified that tests fail as expected (due to the project's purpose for `git bisect` practice) and ensured no unrelated changes to `pubspec.yaml` were included in the final submission.

---
*PR created automatically by Jules for task [2352544438383655447](https://jules.google.com/task/2352544438383655447) started by @tsinis*